### PR TITLE
Fix calendar iframe width

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@
         <section id="calendar" class="calendar-section">
             <h2>Klubbkalender</h2>
             <div class="calendar-container">
-                <iframe src="https://calendar.google.com/calendar/u/0/embed?src=haugesundpk@gmail.com&amp;ctz=Europe/Oslo" style="border:0" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+                <iframe src="https://calendar.google.com/calendar/u/0/embed?src=haugesundpk@gmail.com&amp;ctz=Europe/Oslo" style="border:0;width:100%;height:600px;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
             </div>
         </section>
 

--- a/styles.css
+++ b/styles.css
@@ -243,12 +243,16 @@ body {
 
 .calendar-container {
     margin-top: 2rem;
+    width: 100%;
+    display: flex;
+    justify-content: center;
     border-radius: 10px;
     overflow: hidden;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
 .calendar-container iframe {
+    flex: 1 1 0;
     width: 100%;
     height: 600px;
     border: none;


### PR DESCRIPTION
## Summary
- center and stretch the calendar embed so it takes full width
- ensure the iframe always uses all available space

## Testing
- `git status --short`