### PR TITLE
Convert nav-links containers to lists

### DIFF
--- a/activities.html
+++ b/activities.html
@@ -16,13 +16,13 @@
                 <h1>HPK</h1>
             </a>
         </div>
-        <div class="nav-links">
-            <a href="index.html">Hjem</a>
-            <a href="activities.html">Aktiviteter</a>
-            <a href="membership.html">Medlemskap</a>
-            <a href="schedule.html">Terminliste</a>
-            <a href="contact.html">Kontakt</a>
-        </div>
+        <ul class="nav-links">
+            <li><a href="index.html">Hjem</a></li>
+            <li><a href="activities.html">Aktiviteter</a></li>
+            <li><a href="membership.html">Medlemskap</a></li>
+            <li><a href="schedule.html">Terminliste</a></li>
+            <li><a href="contact.html">Kontakt</a></li>
+        </ul>
         <div class="mobile-menu-btn">
             <i class="fas fa-bars"></i>
         </div>

--- a/contact.html
+++ b/contact.html
@@ -16,13 +16,13 @@
                 <h1>HPK</h1>
             </a>
         </div>
-        <div class="nav-links">
-            <a href="index.html">Hjem</a>
-            <a href="activities.html">Aktiviteter</a>
-            <a href="membership.html">Medlemskap</a>
-            <a href="schedule.html">Terminliste</a>
-            <a href="contact.html">Kontakt</a>
-        </div>
+        <ul class="nav-links">
+            <li><a href="index.html">Hjem</a></li>
+            <li><a href="activities.html">Aktiviteter</a></li>
+            <li><a href="membership.html">Medlemskap</a></li>
+            <li><a href="schedule.html">Terminliste</a></li>
+            <li><a href="contact.html">Kontakt</a></li>
+        </ul>
         <div class="mobile-menu-btn">
             <i class="fas fa-bars"></i>
         </div>

--- a/index.html
+++ b/index.html
@@ -17,13 +17,13 @@
                     <h1>HPK</h1>
                 </a>
             </div>
-            <div class="nav-links">
-                <a href="index.html">Hjem</a>
-                <a href="activities.html">Aktiviteter</a>
-                <a href="membership.html">Medlemskap</a>
-                <a href="schedule.html">Terminliste</a>
-                <a href="contact.html">Kontakt</a>
-            </div>
+            <ul class="nav-links">
+                <li><a href="index.html">Hjem</a></li>
+                <li><a href="activities.html">Aktiviteter</a></li>
+                <li><a href="membership.html">Medlemskap</a></li>
+                <li><a href="schedule.html">Terminliste</a></li>
+                <li><a href="contact.html">Kontakt</a></li>
+            </ul>
             <div class="mobile-menu-btn">
                 <i class="fas fa-bars"></i>
             </div>

--- a/membership.html
+++ b/membership.html
@@ -16,13 +16,13 @@
                 <h1>HPK</h1>
             </a>
         </div>
-        <div class="nav-links">
-            <a href="index.html">Hjem</a>
-            <a href="activities.html">Aktiviteter</a>
-            <a href="membership.html">Medlemskap</a>
-            <a href="schedule.html">Terminliste</a>
-            <a href="contact.html">Kontakt</a>
-        </div>
+        <ul class="nav-links">
+            <li><a href="index.html">Hjem</a></li>
+            <li><a href="activities.html">Aktiviteter</a></li>
+            <li><a href="membership.html">Medlemskap</a></li>
+            <li><a href="schedule.html">Terminliste</a></li>
+            <li><a href="contact.html">Kontakt</a></li>
+        </ul>
         <div class="mobile-menu-btn">
             <i class="fas fa-bars"></i>
         </div>

--- a/schedule.html
+++ b/schedule.html
@@ -16,13 +16,13 @@
                 <h1>HPK</h1>
             </a>
         </div>
-        <div class="nav-links">
-            <a href="index.html">Hjem</a>
-            <a href="activities.html">Aktiviteter</a>
-            <a href="membership.html">Medlemskap</a>
-            <a href="schedule.html">Terminliste</a>
-            <a href="contact.html">Kontakt</a>
-        </div>
+        <ul class="nav-links">
+            <li><a href="index.html">Hjem</a></li>
+            <li><a href="activities.html">Aktiviteter</a></li>
+            <li><a href="membership.html">Medlemskap</a></li>
+            <li><a href="schedule.html">Terminliste</a></li>
+            <li><a href="contact.html">Kontakt</a></li>
+        </ul>
         <div class="mobile-menu-btn">
             <i class="fas fa-bars"></i>
         </div>

--- a/styles.css
+++ b/styles.css
@@ -80,6 +80,9 @@ body {
 .nav-links {
     display: flex;
     gap: 2rem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
 }
 
 .nav-links a {


### PR DESCRIPTION
## Summary
- convert nav link containers in HTML to `<ul>`
- wrap each link in a list item
- reset default list styling in CSS

## Testing
- `npm test` *(fails: cannot find package.json)*
- `npm run lint` *(fails: cannot find package.json)*